### PR TITLE
Remove copy of static library during build step

### DIFF
--- a/recipe/install-libxgboost.sh
+++ b/recipe/install-libxgboost.sh
@@ -10,7 +10,6 @@ XGBOOSTDSO=libxgboost.so
 EXEEXT=
 
 mkdir -p ${LIBDIR} ${INCDIR}/xgboost ${BINDIR} || true
-cp -f ${SRC_DIR}/lib/*.a ${LIBDIR}/
 cp ${SRC_DIR}/xgboost${EXEEXT} ${BINDIR}/
 cp ${SRC_DIR}/lib/${XGBOOSTDSO} ${SODIR}/
 cp -Rf ${SRC_DIR}/include/xgboost ${INCDIR}/


### PR DESCRIPTION
A static library does not get created by the build of xgboost. The attempted copying of a static library is causing an error.