### PR TITLE
Dont limit user to a forced version of certain build tools

### DIFF
--- a/.github/workflows/feedstock-merge.yml
+++ b/.github/workflows/feedstock-merge.yml
@@ -1,0 +1,18 @@
+name: Open-CE Feedstock Merge Triggers
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  version_branch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
+      - uses: conda-incubator/setup-miniconda@v2.0.0
+        with:
+          auto-update-conda: true
+          python-version: "3.8"
+      - uses: open-ce/open-ce/.github/actions/feedstock-merge@master

--- a/meta_recipe/meta.yaml
+++ b/meta_recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 1
+  number: 2
   string: py{{ python | replace(".", "") }}_{{ PKG_BUILDNUM }}   #[build_type == 'cpu']
   string: {{ build_type }}{{ cudatoolkit | replace(".*", "") }}_py{{ python | replace(".", "") }}_{{ PKG_BUILDNUM }} #[build_type == 'cuda']
 
@@ -20,9 +20,13 @@ requirements:
     - cudatoolkit {{ cudatoolkit }} #[build_type == 'cuda']
 
 about:
+  home: https://github.com/dmlc/xgboost/
   license: Apache-2.0
-  license_file: ../LICENSE
+  license_family: APACHE
   summary: A metapackage for selecting a XGBoost variant.
+  description: A metapackage for selecting a XGBoost variant.
+  doc_url: https://xgboost.readthedocs.io/en/latest/
+  dev_url: https://github.com/dmlc/xgboost/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - cmake {{ cmake }}
-    - make {{ make }}
+    - make
     - git >={{ git }}
     - patch
   host:
@@ -42,7 +42,7 @@ outputs:
       build:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
-        - make {{ make }}
+        - make
       host:
         - cudatoolkit {{ cudatoolkit }}        #[build_type == 'cuda']
         - nccl {{ nccl }}                      #[build_type == 'cuda']

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - nccl {{ nccl }}                          #[build_type == 'cuda']
 
 build:
-  number: 1
+  number: 2
   script_env:
     - CUDA_HOME
 
@@ -82,6 +82,7 @@ outputs:
 about:
   home: https://github.com/dmlc/xgboost/
   license: Apache-2.0
+  license_family: APACHE
   license_file: LICENSE
   summary: Scalable, Portable and Distributed Gradient Boosting Library
   description: |

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - nccl {{ nccl }}                          #[build_type == 'cuda']
 
 build:
-  number: 2
+  number: 3
   script_env:
     - CUDA_HOME
 


### PR DESCRIPTION
User shouldnt be forced to have specific version of some general tools (e.g. make), if we are not truly using version-specific features. We arent requiring this consistently across many feedstocks.