### PR TITLE
Remove python dependency from the meta_package

### DIFF
--- a/meta_recipe/meta.yaml
+++ b/meta_recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
   version: {{ version }}
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   run:

--- a/meta_recipe/meta.yaml
+++ b/meta_recipe/meta.yaml
@@ -11,7 +11,6 @@ build:
 
 requirements:
   run:
-    - python {{ python }}
     - libxgboost-base {{ version }}*
     - py-xgboost-base {{ version }}*
     - _xgboost_select =={{ xgboost_select_version }}*


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/master/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/master/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/master/tests/) to validate this change?  

## Description

Having python as a dependency in the meta package breaks things if the channel has more than two versions of python in it. This is because the name for the meta package does not include python in it.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/master/MAINTAINERS.md) requests changes, they must be addressed.
