### PR TITLE
[1.2, 1.1] Remove runtime libgcc pin

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - {{ compiler('cxx') }}
     - libgcc-ng {{ libgcc }}
     - libstdcxx-ng {{ libstdcxx }}
+    - libgfortran-ng {{ libgfortran }}
     - cmake {{ cmake }}
     - make
     - git >={{ git }}
@@ -29,6 +30,7 @@ requirements:
     - nccl {{ nccl }}                          #[build_type == 'cuda']
     - libgcc-ng {{ libgcc }}
     - libstdcxx-ng {{ libstdcxx }}
+    - libgfortran-ng {{ libgfortran }}
 
 build:
   number: 5
@@ -67,12 +69,14 @@ outputs:
         - {{ compiler('cxx') }}
         - libgcc-ng {{ libgcc }}
         - libstdcxx-ng {{ libstdcxx }}
+        - libgfortran-ng {{ libgfortran }}
       host:
         - {{ pin_subpackage('libxgboost-base', exact=True) }}
         - python {{ python }}
         - setuptools {{ setuptools }}
         - libgcc-ng {{ libgcc }}
         - libstdcxx-ng {{ libstdcxx }}
+        - libgfortran-ng {{ libgfortran }}
       run:
         - {{ pin_subpackage('libxgboost-base', exact=True) }}
         - python {{ python }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,6 @@ requirements:
     - {{ compiler('cxx') }}
     - libgcc-ng {{ libgcc }}
     - libstdcxx-ng {{ libstdcxx }}
-    - libgfortran-ng {{ libgfortran }}
     - cmake {{ cmake }}
     - make
     - git >={{ git }}
@@ -30,7 +29,6 @@ requirements:
     - nccl {{ nccl }}                          #[build_type == 'cuda']
     - libgcc-ng {{ libgcc }}
     - libstdcxx-ng {{ libstdcxx }}
-    - libgfortran-ng {{ libgfortran }}
 
 build:
   number: 5

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,11 +14,6 @@ source:
     - 0001-conda-Unbundle-libxgboost.-dll-dylib-so.patch
     - 0002-Fix-R-package-PKGROOT.patch
 
-build:
-  ignore_run_exports:
-    - libgcc-ng
-    - libstdcxx-ng
-
 requirements:
   build:
     - {{ compiler('c') }}
@@ -34,12 +29,9 @@ requirements:
     - nccl {{ nccl }}                          #[build_type == 'cuda']
     - libgcc-ng {{ libgcc }}
     - libstdcxx-ng {{ libstdcxx }}
-  run:
-    - libgcc-ng {{ libgcc }}
-    - libstdcxx-ng {{ libstdcxx }}
 
 build:
-  number: 4
+  number: 5
   script_env:
     - CUDA_HOME
 
@@ -49,9 +41,6 @@ outputs:
     build:
       string: {{ build_type }}_{{ PKG_BUILDNUM }} #[build_type == 'cpu']
       string: {{ build_type }}{{ cudatoolkit | replace(".*", "") }}_{{ PKG_BUILDNUM }} #[build_type == 'cuda']
-      ignore_run_exports:
-        - libgcc-ng
-        - libstdcxx-ng
 
     requirements:
       build:
@@ -65,17 +54,12 @@ outputs:
         - cudatoolkit {{ cudatoolkit }}        #[build_type == 'cuda']
         - nccl {{ nccl }}                      #[build_type == 'cuda']
         - _xgboost_select {{ xgboost_select_version }} 
-        - libgcc-ng {{ libgcc }}
-        - libstdcxx-ng {{ libstdcxx }}
 
   - name: py-xgboost-base
     script: install-py-xgboost.sh
     build:
       string: {{ build_type }}_py{{ python | replace(".", "") }}_{{ PKG_BUILDNUM }} #[build_type == 'cpu']
       string: {{ build_type }}{{ cudatoolkit | replace(".*", "") }}_py{{ python | replace(".", "") }}_{{ PKG_BUILDNUM }} #[build_type == 'cuda']
-      ignore_run_exports:
-        - libgcc-ng
-        - libstdcxx-ng
 
     requirements:
       build:
@@ -96,8 +80,6 @@ outputs:
         - scipy {{ scipy }}
         - scikit-learn
         - _xgboost_select {{ xgboost_select_version }}
-        - libgcc-ng {{ libgcc }}
-        - libstdcxx-ng {{ libstdcxx }}
     test:
       files:
         - test-py-xgboost.py

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -67,14 +67,12 @@ outputs:
         - {{ compiler('cxx') }}
         - libgcc-ng {{ libgcc }}
         - libstdcxx-ng {{ libstdcxx }}
-        - libgfortran-ng {{ libgfortran }}
       host:
         - {{ pin_subpackage('libxgboost-base', exact=True) }}
         - python {{ python }}
         - setuptools {{ setuptools }}
         - libgcc-ng {{ libgcc }}
         - libstdcxx-ng {{ libstdcxx }}
-        - libgfortran-ng {{ libgfortran }}
       run:
         - {{ pin_subpackage('libxgboost-base', exact=True) }}
         - python {{ python }}


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Adjust libgcc and libstdc++ runtime dependencies for xgboost

https://github.com/open-ce/open-ce/issues/452

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
