### PR TITLE
Fixed test_with_pandas and removed libgcc and libstdcxx pins

### DIFF
--- a/recipe/0003-Fixed-a-test-failure-in-test_with_pandas.py.patch
+++ b/recipe/0003-Fixed-a-test-failure-in-test_with_pandas.py.patch
@@ -1,0 +1,34 @@
+From 9306319ad83d2cb667f50572c15f86795f30b427 Mon Sep 17 00:00:00 2001
+From: Nishidha Panpaliya <npanpa23@in.ibm.com>
+Date: Tue, 7 Sep 2021 03:58:11 -0400
+Subject: [PATCH] Fixed a test failure in test_with_pandas.py
+
+---
+ python-package/xgboost/data.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/python-package/xgboost/data.py b/python-package/xgboost/data.py
+index 002f801e..679dc512 100644
+--- a/python-package/xgboost/data.py
++++ b/python-package/xgboost/data.py
+@@ -205,7 +205,7 @@ _pandas_dtype_mapper = {
+ def _transform_pandas_df(data, enable_categorical,
+                          feature_names=None, feature_types=None,
+                          meta=None, meta_type=None):
+-    from pandas import MultiIndex, Int64Index
++    from pandas import MultiIndex, Int64Index, RangeIndex
+     from pandas.api.types import is_sparse, is_categorical_dtype
+ 
+     data_dtypes = data.dtypes
+@@ -227,7 +227,7 @@ def _transform_pandas_df(data, enable_categorical,
+             feature_names = [
+                 ' '.join([str(x) for x in i]) for i in data.columns
+             ]
+-        elif isinstance(data.columns, Int64Index):
++        elif isinstance(data.columns, Int64Index) or isinstance(data.columns, RangeIndex):
+             feature_names = list(map(str, data.columns))
+         else:
+             feature_names = data.columns.format()
+-- 
+2.32.0
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,6 +16,7 @@ source:
     # xgboost patches
     - 0001-conda-Unbundle-libxgboost.-dll-dylib-so.patch
     - 0002-Fix-R-package-PKGROOT.patch
+    - 0003-Fixed-a-test-failure-in-test_with_pandas.py.patch
 
 build:
 
@@ -23,8 +24,6 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - libgcc-ng {{ libgcc }}
-    - libstdcxx-ng {{ libstdcxx }}
     - cmake {{ cmake }}
     - make
     - cudatoolkit {{ cudatoolkit }}            #[build_type == 'cuda']
@@ -32,11 +31,9 @@ requirements:
   host:
     - cudatoolkit {{ cudatoolkit }}            #[build_type == 'cuda']
     - nccl {{ nccl }}                          #[build_type == 'cuda']
-    - libgcc-ng {{ libgcc }}
-    - libstdcxx-ng {{ libstdcxx }}
 
 build:
-  number: 2
+  number: 3 
   run_exports:
     - {{ pin_subpackage("libxgboost", max_pin="x.x.x") }}
 {% if build_type == 'cuda' %}
@@ -122,14 +119,10 @@ outputs:
       build:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
-        - libgcc-ng {{ libgcc }}
-        - libstdcxx-ng {{ libstdcxx }}
       host:
         - {{ pin_subpackage('libxgboost', exact=True) }}
         - python {{ python }}
         - setuptools {{ setuptools }}
-        - libgcc-ng {{ libgcc }}
-        - libstdcxx-ng {{ libstdcxx }}
       run:
         - {{ pin_subpackage('libxgboost', exact=True) }}
         - python {{ python }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     - nccl {{ nccl }}                          #[build_type == 'cuda']
 
 build:
-  number: 3 
+  number: 4
   run_exports:
     - {{ pin_subpackage("libxgboost", max_pin="x.x.x") }}
 {% if build_type == 'cuda' %}

--- a/tests/open-ce-tests.yaml
+++ b/tests/open-ce-tests.yaml
@@ -4,7 +4,7 @@ tests:
         conda install -y git
         git clone --recursive -b v$(python -c "import xgboost; print(xgboost.__version__)") https://github.com/dmlc/xgboost
         conda install -y pytest mock hypothesis matplotlib pandas python-graphviz urllib3 psutil
-        conda install dask=2.30 distributed 
+        conda install -y dask=2.30 distributed 
   - name: Run XGBoost Python tests
     command: |
         cd xgboost


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Fixes following items -
1. Removed pins of libgcc-ng and libstdcxx-ng pins which are no longer needed
2. Fixed a test failure in test_with_pandas.py. 
   - The failure was due to a probable bug in function Dataframe.columns.format() of pandas new version 1.3.2.
   Sample code that recreates the error is 
```
import pandas as pd
print(pd.__version__)
df_int = pd.DataFrame([[1, 1.1], [2, 2.2]], columns=[9, 10])
print("Formatted columns when passed as list: ", df_int.columns.format())
df_range = pd.DataFrame([[1, 1.1], [2, 2.2]], columns=range(9, 11, 1))
print("Formatted columns when passed as range: ", df_range.columns.format())
```
Output: 
```
1.3.2
Formatted columns when passed as list:  ['9 ', '10']
Formatted columns when passed as range:  ['9 ', '10']
```
xgboost code handles the case when columns are passed as list, and hence it returned right values. However, when columns are passed as `range` , pandas.Dataframe.columns.format() is directly called which doesn't give right results. 
With older version of pandas, the problem was only with lists and hence xgboost has handled it itself, but newer version of pandas has the same problem with range columns too.


## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
