### PR TITLE
Use central CUDA capabilities

### DIFF
--- a/recipe/0004-Use-central-cuda-capabilities.patch
+++ b/recipe/0004-Use-central-cuda-capabilities.patch
@@ -1,0 +1,38 @@
+From 42987e0e69e1660cf59d8d2e9c5d391a5c7e37c2 Mon Sep 17 00:00:00 2001
+From: Jason Furmanek <furmanek@us.ibm.com>
+Date: Wed, 8 Sep 2021 12:45:15 -0400
+Subject: [PATCH] Use central cuda capabilities
+
+---
+ cmake/Utils.cmake | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/cmake/Utils.cmake b/cmake/Utils.cmake
+index 3d0973c7..b50caaa8 100644
+--- a/cmake/Utils.cmake
++++ b/cmake/Utils.cmake
+@@ -91,14 +91,19 @@ function(format_gencode_flags flags out)
+   # Set up architecture flags
+   if(NOT flags)
+     if (CUDA_VERSION VERSION_GREATER_EQUAL "11.0")
+-      set(flags "35;50;52;60;61;70;75;80")
++      #set(flags "35;50;52;60;61;70;75;80")
++      string(REPLACE "," ";" tmpflags "$ENV{cuda_levels}")
++      string(REPLACE "." "" flags "${tmpflags}")
+     elseif(CUDA_VERSION VERSION_GREATER_EQUAL "10.0")
+-      set(flags "35;50;52;60;61;70;75")
++      #set(flags "35;50;52;60;61;70;75")
++      string(REPLACE "," ";" tmpflags "$ENV{cuda_levels}")
++      string(REPLACE "." "" flags "${tmpflags}")
+     elseif(CUDA_VERSION VERSION_GREATER_EQUAL "9.0")
+       set(flags "35;50;52;60;61;70")
+     else()
+       set(flags "35;50;52;60;61")
+     endif()
++    message(STATUS "Using Open-CE Centralized CUDA Capabilities: ${flags}")
+   endif()
+ 
+   if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.18")
+-- 
+2.32.0
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ requirements:
     - libstdcxx-ng {{ libstdcxx }}
 
 build:
-  number: 2
+  number: 3
   run_exports:
     - {{ pin_subpackage("libxgboost", max_pin="x.x.x") }}
 {% if build_type == 'cuda' %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,6 +16,7 @@ source:
     # xgboost patches
     - 0001-conda-Unbundle-libxgboost.-dll-dylib-so.patch
     - 0002-Fix-R-package-PKGROOT.patch
+    - 0004-Use-central-cuda-capabilities.patch  #[build_type == 'cuda']
 
 build:
 


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Patch the xgboost cmake so that it uses the central Open-CE CUDA capability settings

cmake output:

```
-- Configured CUDA host compiler: $BUILD_PREFIX/bin/powerpc64le-conda_cos7-linux-gnu-c++
-- The CUDA compiler identification is NVIDIA 11.2.152
-- Check for working CUDA compiler: /usr/local/cuda-11.2//bin/nvcc
-- Check for working CUDA compiler: /usr/local/cuda-11.2//bin/nvcc -- works
-- Detecting CUDA compiler ABI info
-- Detecting CUDA compiler ABI info - done
-- Using Open-CE Centralized CUDA Capabilities: 37;60;70;75;80
-- CUDA GEN_CODE: --generate-code=arch=compute_37,code=sm_37;--generate-code=arch=compute_60,code=sm_60;--generate-code=arch=compute_70,code=sm_70;--generate-code=arch=compute_75,code=sm_75;--generate-code=arch=compute_80,code=sm_80;--generate-code=arch=compute_80,code=compute_80;
```

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
