### PR TITLE
Include Feature shape mismatch fix for s390x

### DIFF
--- a/recipe/0005-Feature-shape-mismatch-fix-s390x.patch
+++ b/recipe/0005-Feature-shape-mismatch-fix-s390x.patch
@@ -1,0 +1,13 @@
+diff --git a/python-package/xgboost/core.py b/python-package/xgboost/core.py
+index 3752d93f..bb639aae 100644
+--- a/python-package/xgboost/core.py
++++ b/python-package/xgboost/core.py
+@@ -2196,7 +2196,7 @@ class Booster(object):
+ 
+     def num_features(self) -> int:
+         '''Number of features in booster.'''
+-        features = ctypes.c_int()
++        features = c_bst_ulong()
+         assert self.handle is not None
+         _check_call(_LIB.XGBoosterGetNumFeature(self.handle, ctypes.byref(features)))
+         return features.value

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,9 +17,10 @@ source:
     - 0001-conda-Unbundle-libxgboost.-dll-dylib-so.patch
     - 0002-Fix-R-package-PKGROOT.patch
     - 0004-Use-central-cuda-capabilities.patch  #[build_type == 'cuda']
+    - 0005-Feature-shape-mismatch-fix-s390x.patch #[s390x]
 
 build:
-  number: 2
+  number: 3
   run_exports:
     - {{ pin_subpackage("libxgboost", max_pin="x.x.x") }}
 


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description
- Backport Feature shape mismatch fix for s390x  in xgboost-feedstock.
  Ref: `https://github.com/dmlc/xgboost/pull/7715`
Fixes # (issue).

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
